### PR TITLE
Fixed

### DIFF
--- a/src/SkillSystem.Aplication/Services/MapService.cs
+++ b/src/SkillSystem.Aplication/Services/MapService.cs
@@ -11,7 +11,6 @@ public static class MapService
         {
             Name = dto.Name,
             Description = dto.Description,
-            UserId = dto.UserId,
             Level = (SkillLevel)SkillLevelDto.NotSet,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = null


### PR DESCRIPTION
fixed

#### PR Classification
Code cleanup to remove unnecessary properties.

#### PR Summary
This pull request removes the `UserId` property from the `Skill` object creation in the `MapService` class, streamlining the data structure. 
- MapService.cs: Removed `UserId` from the `Skill` object being created.
