### PR TITLE
Remove user creation and deletion endpoints

### DIFF
--- a/src/SkillSystem.Api/Endpoints/UserEndpoints.cs
+++ b/src/SkillSystem.Api/Endpoints/UserEndpoints.cs
@@ -22,26 +22,6 @@ public static class UserEndpoints
         .WithName("GetUserById")
         .Produces<UserGetDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
-        group.MapPost("/", async (UserCreateDto userCreateDto, IUserService userService) =>
-        {
-            var userId = await userService.CreateAsync(userCreateDto);
-            return Results.Created($"/api/users/{userId}", new { UserId = userId });
-        })
-        .WithName("CreateUser")
-        .Produces<long>(StatusCodes.Status201Created);
        
-        group.MapDelete("/{id:long}", async (long id, IUserService userService) =>
-        {
-            var user = await userService.GetByIdAsync(id);
-            if (user == null)
-            {
-                return Results.NotFound();
-            }
-            await userService.DeleteAsync(user);
-            return Results.NoContent();
-        })
-        .WithName("DeleteUser")
-        .Produces(StatusCodes.Status204NoContent)
-        .Produces(StatusCodes.Status404NotFound);
     }
 }


### PR DESCRIPTION
Remove user creation and deletion endpoints

The `UserEndpoints` class in `UserEndpoints.cs` has been updated to remove the endpoint definitions for creating and deleting users. The `MapPost` method for user creation and the `MapDelete` method for user deletion, along with their associated logic and response handling, have been eliminated. The remaining functionality now focuses solely on retrieving a user by ID.