### PR TITLE
Add user retrieval by username endpoint

### DIFF
--- a/src/SkillSystem.Api/Endpoints/UserEndpoints.cs
+++ b/src/SkillSystem.Api/Endpoints/UserEndpoints.cs
@@ -22,6 +22,18 @@ public static class UserEndpoints
         .WithName("GetUserById")
         .Produces<UserGetDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
-       
+
+        group.MapGet("/{username}", async (string username, IUserService userService) =>
+        {
+            var user = await userService.GetByUserNameAsync(username);
+            if (user == null)
+            {
+                return Results.NotFound();
+            }
+            return Results.Ok(user);
+        })
+          .WithName("GetUserByUserName")
+          .Produces<UserGetDto>(StatusCodes.Status200OK)
+          .Produces(StatusCodes.Status404NotFound);
     }
 }

--- a/src/SkillSystem.Aplication/Services/IUserService.cs
+++ b/src/SkillSystem.Aplication/Services/IUserService.cs
@@ -11,4 +11,6 @@ public interface IUserService
     Task<PagedResult<UserGetDto>> GetAllAsync(int skip, int take);
     ICollection<UserGetDto> GetAll();
     Task DeleteAsync(UserGetDto user);
+
+    Task<UserGetDto> GetByUserNameAsync(string userName);
 }

--- a/src/SkillSystem.Aplication/Services/UserService.cs
+++ b/src/SkillSystem.Aplication/Services/UserService.cs
@@ -77,4 +77,15 @@ public class UserService : IUserService
         var userDto = MapService.MapUserToUserDto(user);
         return userDto;
     }
+
+    public async Task<UserGetDto> GetByUserNameAsync(string userName)
+    {
+        var user = await _userRepository.SelectByUserNameAsync(userName);
+        if (user == null)
+        {
+            throw new EntityNotFoundException($"User with username '{userName}' not found.");
+        }
+        var userDto = MapService.MapUserToUserDto(user);
+        return userDto;
+    }
 }


### PR DESCRIPTION
Add user retrieval by username endpoint

- Introduced a new endpoint in `UserEndpoints` to fetch user data by username, returning a 404 if not found.
- Updated `IUserService` with `GetByUserNameAsync` method for username-based retrieval.
- Implemented `GetByUserNameAsync` in `UserService` to query the user repository and handle not found cases.